### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for managing Netlify sites. This server enables seamless integration with Netlify's API through MCP, allowing you to create, manage, and deploy sites directly from your MCP-enabled environment.
 
+<a href="https://glama.ai/mcp/servers/@MCERQUA/netlify-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@MCERQUA/netlify-mcp/badge" alt="Netlify Server MCP server" />
+</a>
+
 ## Features
 
 - Create new sites from GitHub repositories


### PR DESCRIPTION
This PR adds a badge for the [Netlify MCP Server](https://glama.ai/mcp/servers/@MCERQUA/netlify-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@MCERQUA/netlify-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@MCERQUA/netlify-mcp/badge" alt="Netlify Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.